### PR TITLE
chore: disable slack notification

### DIFF
--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -42,14 +42,14 @@ jobs:
           dashpay/platform-test-suite:latest \
           yarn run test:suite
 
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@master
-        with:
-          status: ${{ job.status }}
-          notify_when: 'failure'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TESTNET_WEBHOOK_URL }}
+      # - name: Report Status
+      #   if: always()
+      #   uses: ravsamhq/notify-slack-action@master
+      #   with:
+      #     status: ${{ job.status }}
+      #     notify_when: 'failure'
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TESTNET_WEBHOOK_URL }}
 
   smoke-tests:
     name: Run smoke tests


### PR DESCRIPTION
This PR temporarily disables the slack notification on run failure because it is getting annoying.